### PR TITLE
Add Kebab- / Snakecase to available formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,17 @@ The value `<FFSName>` will always be replaced into the component name you specif
 
 Adding a transformer with this pattern `<FFSName | transformer>` will give you the ability to transform your componentname where needed.
 
-The currently supported transformers are: `uppercase`, `lowercase` and `capitalize`. (I'm open for new suggestions any time)
+The currently supported transformers are: 
+ - `uppercase`
+ - `lowercase`
+ - `capitalize`
+ - `lowercasefirstchar`
+ - `camelcase`
+ - `pascalcase`
+ - `snakecase`
+ - `kebabcase`
+
+(I'm open for new suggestions any time)
 
 Given the componentname `myNewComponent` each of the transformers will result in:
 
@@ -113,6 +123,8 @@ myNewComponent => <FFSName | capitalize> => MyNewComponent
 MyNewComponent => <FFSName | lowercasefirstchar> => myNewComponent
 My-new-component => <FFSName | camelcase> => myNewComponent (First letter is lowercased. Every letter behind a special character will be capitalized)
 my-new-component => <FFSName | pascalcase> => MyNewComponent (First letter and every letter behind a special character will be capitalized)
+myNewComponent => <FFSName | snakecase> => my_new_component
+myNewComponent => <FFSName | kebabcase> => my-new-component
 ```
 
 ### Custom Variables

--- a/src/util.ts
+++ b/src/util.ts
@@ -28,6 +28,10 @@ const getTransformedSSFName = (replacement: string, transformer: string) => {
       return toCamelCase(capitalize(replacement));
     case 'camelcase':
       return toCamelCase(lowerCaseFirstChar(replacement));
+    case 'kebabcase':
+      return toKebabCase(replacement);
+    case 'snakecase':
+      return toSnakeCase(replacement);
     default:
       return replacement;
   }
@@ -37,6 +41,19 @@ const toCamelCase = (str: String) =>
   str.replace(/[^A-Za-z0-9]+(.)/g, (_, charAfterSpecialChars) => {
     return charAfterSpecialChars.toUpperCase();
   });
+
+const toKebabCase = (str: String) =>
+  str
+    .replace(/([a-z])([A-Z])/g, '$1-$2')    // get all lowercase letters that are near to uppercase ones
+    .replace(/[\s_]+/g, '-')                // replace all spaces and low dashes
+    .toLowerCase();                         // convert to lower case
+
+
+const toSnakeCase = (str: String) =>
+  str
+    .replace(/([a-z])([A-Z])/g, '$1_$2')    // get all lowercase letters that are near to uppercase ones
+    .replace(/[\s\-]+/g, '_')                // replace all spaces and low dashes
+    .toLowerCase();                         // convert to lower case
 
 const lowerCaseFirstChar = (string: String) => {
   return string.charAt(0).toLowerCase() + string.slice(1);


### PR DESCRIPTION
This adds the ability to format the input name as KebabCase and SnakeCase.

**Examples:**

- SnakeCase:
   `ToggleButton` => `toggle_button`
   `Toggle Button` => `toggle_button`
   `Toggle-Button` => `toggle_button`
   `Toggle_Button` => `toggle_button`

- KebabCase:
   `ToggleButton` => `toggle-button`
   `Toggle Button` => `toggle-button`
   `Toggle-Button` => `toggle-button`
   `Toggle_Button` => `toggle-button`

I didn't test it or ran it through prettier, but the regexes work :)

