### PR TITLE
Fix value checking of the `omitFTName` and `absolutePath` parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
               "absolutePath": {
                 "type": "boolean",
                 "default": false,
-                "description": "If set to true FT will always create all files relative to project root rather than relative to the folder you clicked"
+                "description": "If set to true FT will always create all files relative to project root rather than relative to the folder you clicked. (Can only be set to true if omitParentDirectory is true as well)"
               },
               "structure": {
                 "type": "array",
@@ -245,12 +245,23 @@
                     true,
                     false
                   ]
+                },
+                "absolutePath": {
+                  "enum": [
+                    true,
+                    false
+                  ]
                 }
               }
             },
             "else": {
               "properties": {
                 "omitFTName": {
+                  "enum": [
+                    false
+                  ]
+                },
+                "absolutePath": {
                   "enum": [
                     false
                   ]

--- a/package.json
+++ b/package.json
@@ -242,7 +242,17 @@
               "properties": {
                 "omitFTName": {
                   "enum": [
-                    true
+                    true,
+                    false
+                  ]
+                }
+              }
+            },
+            "else": {
+              "properties": {
+                "omitFTName": {
+                  "enum": [
+                    false
                   ]
                 }
               }

--- a/schemas/ftsettings.json
+++ b/schemas/ftsettings.json
@@ -35,7 +35,7 @@
     "absolutePath": {
       "type": "boolean",
       "default": false,
-      "description": "If set to true FT will always create all files relative to project root rather than relative to the folder you clicked"
+      "description": "If set to true FT will always create all files relative to project root rather than relative to the folder you clicked. (Can only be set to true if omitParentDirectory is true as well)"
     },
     "omitFTName": {
       "type": "boolean",
@@ -117,12 +117,23 @@
           true,
           false
         ]
+      },
+      "absolutePath": {
+        "enum": [
+          true,
+          false
+        ]
       }
     }
   },
   "else": {
     "properties": {
       "omitFTName": {
+        "enum": [
+          false
+        ]
+      },
+      "absolutePath": {
         "enum": [
           false
         ]

--- a/schemas/ftsettings.json
+++ b/schemas/ftsettings.json
@@ -114,7 +114,17 @@
     "properties": {
       "omitFTName": {
         "enum": [
-          true
+          true,
+          false
+        ]
+      }
+    }
+  },
+  "else": {
+    "properties": {
+      "omitFTName": {
+        "enum": [
+          false
         ]
       }
     }


### PR DESCRIPTION
Hello, Dennis!
Thank you for the great extension!

### Description

This PR fixes the `omitFTName` value checking and adds a check for the `absolutePath` parameter based on the value of the `omitParentDirectory` setting.

Looking forward to your review and feedback. Thanks!